### PR TITLE
Remove contradictory words from PriorityQueue spec

### DIFF
--- a/data-structures.md
+++ b/data-structures.md
@@ -108,7 +108,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/Priority_queue) [edited]:
 
 ```javascript
 const pQueue = new PriorityQueue()
-pQueue.enqueue("pizza", 100) // adds an element with priority (number) to the back of the queue.
+pQueue.enqueue("pizza", 100) // adds an element with priority (number) to the queue.
 pQueue.front()               // returns the front element (highest priority) in the queue or null if the queue is empty.
 pQueue.back()                // returns the back element (lowest priority) in the queue or null if the queue is empty.
 pQueue.dequeue()             // returns and removes the front element (highest priority) in the queue or null if the queue is empty.


### PR DESCRIPTION
If element added with enqueue(x, y) has a specified priority, then it cannot be added to the “back”, since “back” means it must have the lowest priority of all the elements. So “the back of” should be deleted.